### PR TITLE
Fix incorrect caret position in iOS

### DIFF
--- a/.changeset/giant-fans-grow.md
+++ b/.changeset/giant-fans-grow.md
@@ -1,0 +1,5 @@
+---
+"@editablejs/editor": patch
+---
+
+Fix incorrect caret position in iOS

--- a/packages/editor/src/plugin/selection-drawing.ts
+++ b/packages/editor/src/plugin/selection-drawing.ts
@@ -95,7 +95,8 @@ export const SelectionDrawing = {
     let rects: DOMRect[] = []
     if (Range.isCollapsed(range)) {
       const domRange = Editable.toDOMRange(editor, range)
-      rects = [domRange.getBoundingClientRect()]
+      const clientRects = domRange.getClientRects();
+      rects = [clientRects[clientRects.length - 1]];
     } else {
       rects = getLineRectsByRange(editor, range)
     }

--- a/packages/editor/src/plugin/selection-drawing.ts
+++ b/packages/editor/src/plugin/selection-drawing.ts
@@ -105,7 +105,6 @@ export const SelectionDrawing = {
       rects = getLineRectsByRange(editor, range)
     }
 
-    console.log('rects2', rects)
     return relative
       ? rects.map(r => {
           const [x, y] = Editable.toRelativePosition(editor, r.left, r.top)

--- a/packages/editor/src/plugin/selection-drawing.ts
+++ b/packages/editor/src/plugin/selection-drawing.ts
@@ -95,8 +95,8 @@ export const SelectionDrawing = {
     let rects: DOMRect[] = []
     if (Range.isCollapsed(range)) {
       const domRange = Editable.toDOMRange(editor, range)
-      const clientRects = domRange.getClientRects();
-      rects = [clientRects[clientRects.length - 1]];
+      const clientRects = domRange.getClientRects()
+      rects = [clientRects[clientRects.length - 1]]
     } else {
       rects = getLineRectsByRange(editor, range)
     }

--- a/packages/editor/src/plugin/selection-drawing.ts
+++ b/packages/editor/src/plugin/selection-drawing.ts
@@ -96,11 +96,16 @@ export const SelectionDrawing = {
     if (Range.isCollapsed(range)) {
       const domRange = Editable.toDOMRange(editor, range)
       const clientRects = domRange.getClientRects()
-      rects = [clientRects[clientRects.length - 1]]
+      if (clientRects.length > 1) {
+        rects = [clientRects[clientRects.length - 1]]
+      } else {
+        rects = [domRange.getBoundingClientRect()]
+      }
     } else {
       rects = getLineRectsByRange(editor, range)
     }
 
+    console.log('rects2', rects)
     return relative
       ? rects.map(r => {
           const [x, y] = Editable.toRelativePosition(editor, r.left, r.top)


### PR DESCRIPTION
**Description**

When focus at the start of a middle line in a paragraph, `getBoundingClientRect` wil get an incorrect height and using `getClientRects` can get the correct height

![image](https://user-images.githubusercontent.com/11460856/217715667-fdd3c23e-736b-4781-9efa-f413f963d965.png)

After fixing：
<img width="376" alt="image" src="https://user-images.githubusercontent.com/11460856/217726377-d7a81b2f-e7be-4def-b78e-ac92e2f56d68.png">


**Issue**

Fixes: #81 

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `pnpm test`.
- [x] The linter passes with `pnpm lint`. (Fix errors with `pnpm fix`.)
- [x] The relevant examples still work. (Run examples with `pnpm start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm changeset`.)

