### PR TITLE
Fix plugin-image syntax error

### DIFF
--- a/apps/docs/src/content/learn/plugin-image.md
+++ b/apps/docs/src/content/learn/plugin-image.md
@@ -31,19 +31,17 @@ const defaultValue = [
     children: [
       { text: 'This is a' },
       {
-        {
-          url: 'https://raw.githubusercontent.com/editablejs/editable/main/assets/sparticle-logo.png',
-          state: 'done',
-          width: 386,
-          height: 82,
-          type: 'image',
-          children: [
-            {
-              text: '',
-            },
-          ],
-          percentage: 100,
-        }
+        url: 'https://raw.githubusercontent.com/editablejs/editable/main/assets/sparticle-logo.png',
+        state: 'done',
+        width: 386,
+        height: 82,
+        type: 'image',
+        children: [
+          {
+            text: '',
+          },
+        ],
+        percentage: 100,
       },
       { text: ' image.'}
     ]

--- a/apps/docs/src/content/learn/plugin-image.zh-CN.md
+++ b/apps/docs/src/content/learn/plugin-image.zh-CN.md
@@ -31,19 +31,17 @@ const defaultValue = [
     children: [
       { text: 'This is a' },
       {
-        {
-          url: 'https://raw.githubusercontent.com/editablejs/editable/main/assets/sparticle-logo.png',
-          state: 'done',
-          width: 386,
-          height: 82,
-          type: 'image',
-          children: [
-            {
-              text: '',
-            },
-          ],
-          percentage: 100,
-        }
+        url: 'https://raw.githubusercontent.com/editablejs/editable/main/assets/sparticle-logo.png',
+        state: 'done',
+        width: 386,
+        height: 82,
+        type: 'image',
+        children: [
+          {
+            text: '',
+          },
+        ],
+        percentage: 100,
       },
       { text: ' image.'}
     ]


### PR DESCRIPTION
**Description**

https://docs.editablejs.com/learn/plugin-image Usage section has an syntax error.

<img width="1044" alt="스크린샷 2023-06-05 오후 11 21 03" src="https://github.com/editablejs/editable/assets/26870568/1779a486-f98a-4121-ab0c-e9b936797257">

After fixing：

<img width="1047" alt="image" src="https://github.com/editablejs/editable/assets/26870568/6209f4ba-ff65-4ec9-9c29-79f38466cf23">

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `pnpm test`.
- [x] The linter passes with `pnpm lint`. (Fix errors with `pnpm fix`.)
- [x] The relevant examples still work. (Run examples with `pnpm start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm changeset`.)

