### PR TITLE
Fix copy table issues like: with colspan or rowspan cause page collapse and so on

### DIFF
--- a/.changeset/five-melons-travel.md
+++ b/.changeset/five-melons-travel.md
@@ -1,0 +1,6 @@
+---
+'@editablejs/deserializer': patch
+'@editablejs/plugin-table': patch
+---
+
+fix: fix issues about copy tables from other html page which may cause page collapse and wrong enter press respond and missing table header and missing last empty cell.

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 node_modules
 .pnp
 .pnp.js
-
+.history
 # testing
 coverage
 

--- a/packages/deserializer/src/html.ts
+++ b/packages/deserializer/src/html.ts
@@ -91,8 +91,18 @@ export const HTMLDeserializer = {
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
       if (child.nodeName === 'TABLE') {
+        let colCount = 0;
         for (let rowIndex = 0; rowIndex < child.rows.length; rowIndex++) {
           const row = child.rows[rowIndex];
+          // 计算第一行的列数，用colspan累加
+          if (rowIndex === 0) {
+            for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex++) {
+              const cell = row.cells[cellIndex];
+              const colspan = cell.getAttribute('colspan') ?? 1
+              colCount += colspan - 0;
+            }
+          }
+          
           
           for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex++) {
             const cell = row.cells[cellIndex];
@@ -128,6 +138,17 @@ export const HTMLDeserializer = {
               }
             }
           }
+          let cellsLength = row.cells.length;
+          if (cellsLength < colCount) {
+            for (let i = 0; i < colCount - cellsLength; i++) {
+              const newCell = row.insertCell();
+              // 设置当前newCell的colspan和rowspan都为1
+              newCell.setAttribute('colspan', '1')
+              newCell.setAttribute('rowspan', '1')
+              // 设置当前newCell的文本为displaynone
+              newCell.textContent = '';
+            }
+          }
         }
       }
       // 解析child的innerHTML，并循环遍历内部的所有strike，并增加style：text-decoration:line-through;
@@ -142,7 +163,7 @@ export const HTMLDeserializer = {
             span.style.setProperty(property, strike.style.getPropertyValue(property));
           }
           span.style.textDecoration = 'line-through';
-          // 将当前元素作为兄弟元素插入到strike后面，并把strike隐藏掉
+          // 将当前元素作为兄弟元素插入到strike后面
           strike.insertAdjacentElement('afterend', span);
         }
         while (strikes.length > 0) {

--- a/packages/deserializer/src/html.ts
+++ b/packages/deserializer/src/html.ts
@@ -145,7 +145,7 @@ export const HTMLDeserializer = {
               // 设置当前newCell的colspan和rowspan都为1
               newCell.setAttribute('colspan', '1')
               newCell.setAttribute('rowspan', '1')
-              // 设置当前newCell的文本为displaynone
+              // 设置当前newCell的文本为空
               newCell.textContent = '';
             }
           }

--- a/packages/plugins/list/src/task/plugin/with-task-list.tsx
+++ b/packages/plugins/list/src/task/plugin/with-task-list.tsx
@@ -70,9 +70,11 @@ const TaskElement = ({ checked, onChange }: TaskProps) => {
   )
 }
 
-// 不期望任务列表选中后出现下划线，去掉 &[data-task-checked='true'] {下面的 ${tw`line-through`}
+// 如果不期望任务列表选中后出现下划线，去掉 &[data-task-checked='true'] {下面的 ${tw`line-through`}，
+// 本次revert，保留原项目设计，后期通过脚本实现调整
 const StyledTask = styled(ListStyles)`
   &[data-task-checked='true'] {
+      ${tw`line-through`}
 
       ${TaskCheckboxInnerStyles} {
         background-color: ${theme('colors.primary')};

--- a/packages/plugins/list/src/task/plugin/with-task-list.tsx
+++ b/packages/plugins/list/src/task/plugin/with-task-list.tsx
@@ -1,7 +1,7 @@
-import { RenderElementProps, ElementAttributes, Editable, Hotkey } from '@editablejs/editor'
-import { Transforms, List } from '@editablejs/models'
-import tw, { styled, css, theme } from 'twin.macro'
-import { ListStyles, ListLabelStyles, renderList } from '../../styles'
+import { Editable, ElementAttributes, Hotkey, RenderElementProps } from '@editablejs/editor'
+import { List, Transforms } from '@editablejs/models'
+import tw, { css, styled, theme } from 'twin.macro'
+import { ListLabelStyles, ListStyles, renderList } from '../../styles'
 import { DATA_TASK_CHECKED_KEY, TASK_LIST_KEY } from '../constants'
 import { TaskList } from '../interfaces/task-list'
 import { TaskListHotkey, TaskListOptions } from '../options'
@@ -70,9 +70,9 @@ const TaskElement = ({ checked, onChange }: TaskProps) => {
   )
 }
 
+// 不期望任务列表选中后出现下划线，去掉 &[data-task-checked='true'] {下面的 ${tw`line-through`}
 const StyledTask = styled(ListStyles)`
   &[data-task-checked='true'] {
-      ${tw`line-through`}
 
       ${TaskCheckboxInnerStyles} {
         background-color: ${theme('colors.primary')};

--- a/packages/plugins/table/src/cell/deserializer/html.ts
+++ b/packages/plugins/table/src/cell/deserializer/html.ts
@@ -9,7 +9,7 @@ export const withTableCellHTMLDeserializerTransform: HTMLDeserializerWithTransfo
 ) => {
   return (node, options = {}) => {
     const { text } = options
-    if (isDOMHTMLElement(node) && node.nodeName === 'TD') {
+    if (isDOMHTMLElement(node) && ['TD', 'TH'].includes(node.nodeName)) {
       const children: Descendant[] = []
       for (const child of node.childNodes) {
         const content = serializer.transform(child, {

--- a/packages/plugins/table/src/cell/deserializer/html.ts
+++ b/packages/plugins/table/src/cell/deserializer/html.ts
@@ -22,34 +22,45 @@ export const withTableCellHTMLDeserializerTransform: HTMLDeserializerWithTransfo
       }
       const { colSpan, rowSpan } = node as HTMLTableCellElement
       // 遍历children，每个子元素再次放入到children中
-      let ifHiddenCell = false;
-      const spanArray = [];
+      let ifHiddenCell = false
+      const spanArray: number[] = []
       children.forEach(child => {
+        // 2024/01/31 10:31:42@需求ID: 产品工作站代码优化@ZhaiCongrui/GW00247400：处理有的带有 链接 的单元格，编辑时回车光标跳到下个单元格的问题
+        // child  的 type 为 link时，会有此类问题，所以单独处理
+        if (child.type === 'link') {
+          const copyChild = { ...child }
+          Reflect.ownKeys(child).forEach(i => delete child[i])
+          child.type = 'paragraph'
+          child.children = []
+          child.children[0] = copyChild
+        }
         if (child.children === undefined) {
           if (child.text.indexOf('displaynone||||||') > -1) {
-            ifHiddenCell = true;
-            const startRow = child.text.split('||||||')[1];
-            const startCol = child.text.split('||||||')[2];
-            spanArray.push(startRow - 0);
-            spanArray.push(startCol - 0);
+            ifHiddenCell = true
+            const startRow = child.text.split('||||||')[1]
+            const startCol = child.text.split('||||||')[2]
+            spanArray.push(startRow - 0)
+            spanArray.push(startCol - 0)
           }
-          const tempChild = [{...child}];
+          const tempChild = [{ ...child }]
           //把child的所有属性移除
-          Object.keys(child).forEach(key => delete child[key]);
-          child.children = tempChild;
+          Object.keys(child).forEach(key => delete child[key])
+          child.children = tempChild
         }
-      });
+      })
 
-      const cell = ifHiddenCell ? {
-        type: TABLE_CELL_KEY,
-        children,
-        span: spanArray,
-      } : {
-        type: TABLE_CELL_KEY,
-        children,
-        colspan: colSpan,
-        rowspan: rowSpan,
-      }
+      const cell = ifHiddenCell
+        ? {
+            type: TABLE_CELL_KEY,
+            children,
+            span: spanArray,
+          }
+        : {
+            type: TABLE_CELL_KEY,
+            children,
+            colspan: colSpan,
+            rowspan: rowSpan,
+          }
       return [cell]
     }
     return next(node, options)

--- a/packages/plugins/table/src/cell/deserializer/html.ts
+++ b/packages/plugins/table/src/cell/deserializer/html.ts
@@ -1,18 +1,17 @@
 import { HTMLDeserializerWithTransform } from '@editablejs/deserializer/html'
 import { Descendant, isDOMHTMLElement } from '@editablejs/models'
 import { TABLE_CELL_KEY } from '../constants'
-import { TableCell } from '../interfaces/table-cell'
 
 export const withTableCellHTMLDeserializerTransform: HTMLDeserializerWithTransform = (
   next,
-  serializer,
+  deserializer,
 ) => {
   return (node, options = {}) => {
     const { text } = options
     if (isDOMHTMLElement(node) && ['TD', 'TH'].includes(node.nodeName)) {
       const children: Descendant[] = []
       for (const child of node.childNodes) {
-        const content = serializer.transform(child, {
+        const content = deserializer.transform(child, {
           text,
           matchNewline: true,
         })
@@ -22,7 +21,30 @@ export const withTableCellHTMLDeserializerTransform: HTMLDeserializerWithTransfo
         children.push({ children: [{ text: '' }] })
       }
       const { colSpan, rowSpan } = node as HTMLTableCellElement
-      const cell: TableCell = {
+      // 遍历children，每个子元素再次放入到children中
+      let ifHiddenCell = false;
+      const spanArray = [];
+      children.forEach(child => {
+        if (child.children === undefined) {
+          if (child.text.indexOf('displaynone||||||') > -1) {
+            ifHiddenCell = true;
+            const startRow = child.text.split('||||||')[1];
+            const startCol = child.text.split('||||||')[2];
+            spanArray.push(startRow - 0);
+            spanArray.push(startCol - 0);
+          }
+          const tempChild = [{...child}];
+          //把child的所有属性移除
+          Object.keys(child).forEach(key => delete child[key]);
+          child.children = tempChild;
+        }
+      });
+
+      const cell = ifHiddenCell ? {
+        type: TABLE_CELL_KEY,
+        children,
+        span: spanArray,
+      } : {
         type: TABLE_CELL_KEY,
         children,
         colspan: colSpan,

--- a/packages/plugins/table/src/cell/plugin/with-table-cell.tsx
+++ b/packages/plugins/table/src/cell/plugin/with-table-cell.tsx
@@ -1,7 +1,7 @@
 import { Editable } from '@editablejs/editor'
 import { GridCell, Node } from '@editablejs/models'
-import { setOptions, TableCellOptions } from '../options'
 import { CellInnerStyles, CellStyles } from '../../components/styles'
+import { TableCellOptions, setOptions } from '../options'
 import { TableCellEditor } from './table-cell-editor'
 
 export const withTableCell = <T extends Editable>(editor: T, options: TableCellOptions = {}) => {
@@ -22,7 +22,7 @@ export const withTableCell = <T extends Editable>(editor: T, options: TableCellO
         <CellStyles
           rowSpan={element.rowspan ?? 1}
           colSpan={element.colspan ?? 1}
-          style={{ ...style, display: element.span ? 'none' : '' }}
+          style={{ ...style, display: element.span || element.children[0]?.text?.toString().indexOf('displaynone||||||') > -1 ? 'none' : '' }}
           {...rest}
         >
           <CellInnerStyles>{children}</CellInnerStyles>

--- a/packages/plugins/table/src/components/action.tsx
+++ b/packages/plugins/table/src/components/action.tsx
@@ -1,7 +1,16 @@
-import { cancellablePromise, Editable, useCancellablePromises, Slot } from '@editablejs/editor'
-import { Transforms, Grid, Editor } from '@editablejs/models'
-import * as React from 'react'
+import { Editable, Slot, cancellablePromise, useCancellablePromises } from '@editablejs/editor'
+import { Editor, Grid, Transforms } from '@editablejs/models'
 import { Icon } from '@editablejs/ui'
+import * as React from 'react'
+import { TABLE_CELL_KEY } from '../cell/constants'
+import { defaultTableMinColWidth } from '../cell/options'
+import { TableDrag, useTableDragTo, useTableDragging } from '../hooks/use-drag'
+import { TableRow } from '../row'
+import { TABLE_ROW_KEY } from '../row/constants'
+import { defaultTableMinRowHeight } from '../row/options'
+import { RowStore } from '../row/store'
+import { useTableOptions } from '../table/options'
+import { adaptiveExpandColumnWidthInContainer } from '../table/utils'
 import {
   ColsInsertIconStyles,
   ColsInsertLineStyles,
@@ -16,15 +25,6 @@ import {
   RowsSplitLineStyles,
   RowsSplitStyles,
 } from './styles'
-import { TableDrag, useTableDragging, useTableDragTo } from '../hooks/use-drag'
-import { TABLE_CELL_KEY } from '../cell/constants'
-import { TableRow } from '../row'
-import { TABLE_ROW_KEY } from '../row/constants'
-import { useTableOptions } from '../table/options'
-import { defaultTableMinColWidth } from '../cell/options'
-import { defaultTableMinRowHeight } from '../row/options'
-import { adaptiveExpandColumnWidthInContainer } from '../table/utils'
-import { RowStore } from '../row/store'
 
 const TYPE_COL = 'col'
 const TYPE_ROW = 'row'
@@ -199,6 +199,23 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
         }
         newColsWidth[start] = width
         Transforms.setNodes<Grid>(editor, { colsWidth: newColsWidth }, { at: path })
+        // // 这里需要循环遍历每一列的高度RowStore.getContentHeight(row)，并重新更新列高度 RowStore.setContentHeight(row, contentHeight) 和Transforms.setNodes<TableRow>(editor, { height: h }, { at: path.concat(start) })
+        // const newGrid = Grid.above(editor, path)
+        // if (!newGrid) return
+        // const { children: rows } = newGrid[0]
+        // let contentHeight = 0
+        // for (let i = 0; i < rows.length; i++) {
+        //   const row = rows[i]
+        //   const ch = RowStore.getContentHeight(row)
+        //   const child = Editable.toDOMNode(editor, row).firstElementChild
+        //   if (!child) continue
+        //   const rect = child.getBoundingClientRect()
+        //   contentHeight = Math.max(contentHeight, rect.height + 2, minRowHeight)
+        //   if (ch !== contentHeight) {
+        //     RowStore.setContentHeight(row, contentHeight)
+        //     Transforms.setNodes<TableRow>(editor, { height: contentHeight }, { at: path.concat(i) })
+        //   }
+        // }
       } else if (type === TYPE_ROW) {
         const row = table.children[start]
         const { height, children: cells } = row
@@ -229,6 +246,123 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
   const cancellablePromisesApi = useCancellablePromises()
 
   const handleDragSplitUp = React.useCallback(() => {
+    if (!dragRef.current) return;
+    const { type: type2 } = dragRef.current;
+    const path = Editable.findPath(editor, table);
+
+    if (type2 === TYPE_COL) {
+      const newGrid = Grid.above(editor, path);
+      if (!newGrid) return;
+      const { children: rows } = newGrid[0];
+      let contentHeight = 0;
+      const heightArray: number[] = [];
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        const trRow = Editable.toDOMNode(editor, row);
+        // 2024/01/19 10:40:43 @guoxiaona/GW00234847：遍历trRow,判断所有子元素中rowSpan为1且colSpan为1，且style中的display不为none的子元素
+        const trRowChildrenArray = Array.from(trRow.children);
+        let child: any = null;
+        trRowChildrenArray.forEach((item: any) => {
+          const rowspan = item.rowSpan;
+          const colspan = item.colSpan;
+          const style = item.style;
+          const display = style.display;
+          if (rowspan === 1 && colspan === 1 && display !== "none") {
+            child = item;
+          }
+        });
+        if (!child) continue;
+        const rect = child.getBoundingClientRect();
+        contentHeight = Math.max(rect.height, minRowHeight);
+        heightArray.push(contentHeight);
+      }
+      // 2024/01/19 10:41:10 @guoxiaona/GW00234847：heightArray中当前数之前所有数值的和
+      const heightArrayMapOnlyPrev = heightArray.map((item, index) => {
+        let sum = 0;
+        for (let i = 0; i < index; i++) {
+          sum += heightArray[i];
+        }
+        return sum;
+      });
+      // 2024/01/19 10:41:27 @guoxiaona/GW00234847：heightArray中当前数和之前所有数值的和
+      const heightArrayMapAllPrev = heightArray.map((item, index) => {
+        let sum = 0;
+        for (let i = 0; i <= index; i++) {
+          sum += heightArray[i];
+        }
+        return sum;
+      });
+
+      const cld = Editable.toDOMNode(editor, rows[0]).firstElementChild;
+
+      // 2024/01/19 10:41:43 @guoxiaona/GW00234847：获取child的祖先节点table所在的节点的父节点的第二个子节点
+      const t = cld?.closest("table");
+      const tableParent = t?.parentElement;
+      const tableParentChildrenArray = Array.from(tableParent!.children);
+      const tableTopBorder = tableParentChildrenArray?.[0];
+      const tableLeftBorder = tableParentChildrenArray?.[1];
+      // 2024/01/19 10:42:07 @guoxiaona/GW00234847：获取tableLeftBorder中所有子元素带有属性data-table-row的，并按照该属性值放到一个数组中borderHeightArray
+      const borderHeightArray: number[] = [];
+      const tableLeftBorderChildrenArray = Array.from(
+        tableLeftBorder?.children
+      );
+      const tableLeftBorderPerRowArray: any[] = [];
+      tableLeftBorderChildrenArray.forEach((item: any) => {
+        if (item.dataset.tableRow) {
+          tableLeftBorderPerRowArray.push(item);
+          // 2024/01/19 10:42:28 @guoxiaona/GW00234847：需要从item中获取当前style中的height值，并放入borderHeightArray中
+          const style = item.style;
+          const height = Number(style.height.replace("px", ""));
+          borderHeightArray.push(height);
+        }
+      });
+      // 2024/01/19 10:42:47 @guoxiaona/GW00234847：检测heightArray和borderHeightArray对应下标的数值相差是否在5以内，如果是，则不做任何处理，否则更新当前行对应的高度
+      let ifRowHeightUpdated = false;
+      heightArray.forEach((item, index) => {
+        const borderHeight = borderHeightArray[index];
+        const itemNumber = Number(item);
+        const diff = Math.abs(borderHeight - itemNumber);
+        // 2024/01/19 10:43:20 @guoxiaona/GW00234847：在这里更新当前行及后面行的高度及top值
+        if (diff > 10 || ifRowHeightUpdated) {
+          ifRowHeightUpdated = true;
+          // 2024/01/19 10:43:33 @guoxiaona/GW00234847：调整当前tableLeftBorderPerRowArray[index]的高度为heightArray[index] + 1,top为heightArrayMapOnlyPrev[index]
+          const currentRow = tableLeftBorderPerRowArray[index];
+          const currentRowStyle = currentRow.style;
+          currentRowStyle.height = `${itemNumber + 1}px`;
+          currentRowStyle.top = `${heightArrayMapOnlyPrev[index]}px`;
+          // 2024/01/19 10:43:47 @guoxiaona/GW00234847：调整当前tableLeftBorderPerRowArray[index]后面两个兄弟元素的top值为heightArrayMapAllPrev[index] - 1
+          // 2024/01/19 10:44:00 @guoxiaona/GW00234847：需要重新获取后面两个兄弟元素，这两个兄弟元素没在tableLeftBorderPerRowArray[index]里
+          const nextSibling = currentRow.nextElementSibling;
+          const nextSiblingStyle = nextSibling.style;
+          nextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`;
+          const nextNextSibling = nextSibling.nextElementSibling;
+          const nextNextSiblingStyle = nextNextSibling.style;
+          nextNextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`;
+        }
+      });
+      // 2024/01/19 10:44:13 @guoxiaona/GW00234847：如果行高调整过，则需要对应调整列的高度为heightArrayMapAllPrev的最后一个元素的值 + 9
+      if (ifRowHeightUpdated) {
+        // 2024/01/19 10:44:25 @guoxiaona/GW00234847：获取tableTopBorder中所有子元素带有属性data-table-col的子元素，并放到一个数组中tableTopBorderPerColArray
+        const tableTopBorderChildrenArray = Array.from(
+          tableTopBorder?.children
+        );
+        const tableTopBorderPerColArray: any[] = [];
+        tableTopBorderChildrenArray.forEach((item: any) => {
+          if (item.dataset.tableCol) {
+            tableTopBorderPerColArray.push(item);
+          }
+        });
+        // 2024/01/19 10:44:46 @guoxiaona/GW00234847：遍历tableTopBorderPerColArray中每一个元素的兄弟节点的兄弟节点，找到后，将高度调整为heightArrayMapAllPrev的最后一个元素的值 + 9
+        tableTopBorderPerColArray.forEach((item) => {
+          const nextNextSibling = item.nextElementSibling.nextElementSibling;
+          const nextNextSiblingStyle = nextNextSibling.style;
+          nextNextSiblingStyle.height = `${
+            heightArrayMapAllPrev[heightArrayMapAllPrev.length - 1] + 16
+          }px`;
+        });
+      }
+    }
+
     dragRef.current = null
     isDrag.current = false
     setHover(false)

--- a/packages/plugins/table/src/components/action.tsx
+++ b/packages/plugins/table/src/components/action.tsx
@@ -199,23 +199,6 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
         }
         newColsWidth[start] = width
         Transforms.setNodes<Grid>(editor, { colsWidth: newColsWidth }, { at: path })
-        // // 这里需要循环遍历每一列的高度RowStore.getContentHeight(row)，并重新更新列高度 RowStore.setContentHeight(row, contentHeight) 和Transforms.setNodes<TableRow>(editor, { height: h }, { at: path.concat(start) })
-        // const newGrid = Grid.above(editor, path)
-        // if (!newGrid) return
-        // const { children: rows } = newGrid[0]
-        // let contentHeight = 0
-        // for (let i = 0; i < rows.length; i++) {
-        //   const row = rows[i]
-        //   const ch = RowStore.getContentHeight(row)
-        //   const child = Editable.toDOMNode(editor, row).firstElementChild
-        //   if (!child) continue
-        //   const rect = child.getBoundingClientRect()
-        //   contentHeight = Math.max(contentHeight, rect.height + 2, minRowHeight)
-        //   if (ch !== contentHeight) {
-        //     RowStore.setContentHeight(row, contentHeight)
-        //     Transforms.setNodes<TableRow>(editor, { height: contentHeight }, { at: path.concat(i) })
-        //   }
-        // }
       } else if (type === TYPE_ROW) {
         const row = table.children[start]
         const { height, children: cells } = row
@@ -316,7 +299,7 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
           borderHeightArray.push(height);
         }
       });
-      // 2024/01/19 10:42:47 @guoxiaona/GW00234847：检测heightArray和borderHeightArray对应下标的数值相差是否在5以内，如果是，则不做任何处理，否则更新当前行对应的高度
+      // 2024/01/19 10:42:47 @guoxiaona/GW00234847：检测heightArray和borderHeightArray对应下标的数值相差是否在10(行高大于10)以内，如果是，则不做任何处理，否则更新当前行对应的高度
       let ifRowHeightUpdated = false;
       heightArray.forEach((item, index) => {
         const borderHeight = borderHeightArray[index];
@@ -357,7 +340,7 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
           const nextNextSibling = item.nextElementSibling.nextElementSibling;
           const nextNextSiblingStyle = nextNextSibling.style;
           nextNextSiblingStyle.height = `${
-            heightArrayMapAllPrev[heightArrayMapAllPrev.length - 1] + 16
+            heightArrayMapAllPrev[heightArrayMapAllPrev.length - 1] + 9
           }px`;
         });
       }

--- a/packages/plugins/table/src/components/action.tsx
+++ b/packages/plugins/table/src/components/action.tsx
@@ -229,120 +229,116 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
   const cancellablePromisesApi = useCancellablePromises()
 
   const handleDragSplitUp = React.useCallback(() => {
-    if (!dragRef.current) return;
-    const { type: type2 } = dragRef.current;
-    const path = Editable.findPath(editor, table);
+    if (!dragRef.current) return
+    const { type: type2 } = dragRef.current
+    const path = Editable.findPath(editor, table)
 
     if (type2 === TYPE_COL) {
-      const newGrid = Grid.above(editor, path);
-      if (!newGrid) return;
-      const { children: rows } = newGrid[0];
-      let contentHeight = 0;
-      const heightArray: number[] = [];
+      const newGrid = Grid.above(editor, path)
+      if (!newGrid) return
+      const { children: rows } = newGrid[0]
+      let contentHeight = 0
+      const heightArray: number[] = []
       for (let i = 0; i < rows.length; i++) {
-        const row = rows[i];
-        const trRow = Editable.toDOMNode(editor, row);
+        const row = rows[i]
+        const trRow = Editable.toDOMNode(editor, row)
         // 2024/01/19 10:40:43 @guoxiaona/GW00234847：遍历trRow,判断所有子元素中rowSpan为1且colSpan为1，且style中的display不为none的子元素
-        const trRowChildrenArray = Array.from(trRow.children);
-        let child: any = null;
+        const trRowChildrenArray = Array.from(trRow.children)
+        let child: any = null
         trRowChildrenArray.forEach((item: any) => {
-          const rowspan = item.rowSpan;
-          const colspan = item.colSpan;
-          const style = item.style;
-          const display = style.display;
-          if (rowspan === 1 && colspan === 1 && display !== "none") {
-            child = item;
+          const rowspan = item.rowSpan
+          const colspan = item.colSpan
+          const style = item.style
+          const display = style.display
+          if (rowspan === 1 && colspan === 1 && display !== 'none') {
+            child = item
           }
-        });
-        if (!child) continue;
-        const rect = child.getBoundingClientRect();
-        contentHeight = Math.max(rect.height, minRowHeight);
-        heightArray.push(contentHeight);
+        })
+        if (!child) continue
+        const rect = child.getBoundingClientRect()
+        contentHeight = Math.max(rect.height, minRowHeight)
+        heightArray.push(contentHeight)
       }
       // 2024/01/19 10:41:10 @guoxiaona/GW00234847：heightArray中当前数之前所有数值的和
       const heightArrayMapOnlyPrev = heightArray.map((item, index) => {
-        let sum = 0;
+        let sum = 0
         for (let i = 0; i < index; i++) {
-          sum += heightArray[i];
+          sum += heightArray[i]
         }
-        return sum;
-      });
+        return sum
+      })
       // 2024/01/19 10:41:27 @guoxiaona/GW00234847：heightArray中当前数和之前所有数值的和
       const heightArrayMapAllPrev = heightArray.map((item, index) => {
-        let sum = 0;
+        let sum = 0
         for (let i = 0; i <= index; i++) {
-          sum += heightArray[i];
+          sum += heightArray[i]
         }
-        return sum;
-      });
+        return sum
+      })
 
-      const cld = Editable.toDOMNode(editor, rows[0]).firstElementChild;
+      const cld = Editable.toDOMNode(editor, rows[0]).firstElementChild
 
       // 2024/01/19 10:41:43 @guoxiaona/GW00234847：获取child的祖先节点table所在的节点的父节点的第二个子节点
-      const t = cld?.closest("table");
-      const tableParent = t?.parentElement;
-      const tableParentChildrenArray = Array.from(tableParent!.children);
-      const tableTopBorder = tableParentChildrenArray?.[0];
-      const tableLeftBorder = tableParentChildrenArray?.[1];
+      const t = cld?.closest('table')
+      const tableParent = t?.parentElement
+      const tableParentChildrenArray = Array.from(tableParent!.children)
+      const tableTopBorder = tableParentChildrenArray?.[0]
+      const tableLeftBorder = tableParentChildrenArray?.[1]
       // 2024/01/19 10:42:07 @guoxiaona/GW00234847：获取tableLeftBorder中所有子元素带有属性data-table-row的，并按照该属性值放到一个数组中borderHeightArray
-      const borderHeightArray: number[] = [];
-      const tableLeftBorderChildrenArray = Array.from(
-        tableLeftBorder?.children
-      );
-      const tableLeftBorderPerRowArray: any[] = [];
+      const borderHeightArray: number[] = []
+      const tableLeftBorderChildrenArray = Array.from(tableLeftBorder?.children)
+      const tableLeftBorderPerRowArray: any[] = []
       tableLeftBorderChildrenArray.forEach((item: any) => {
         if (item.dataset.tableRow) {
-          tableLeftBorderPerRowArray.push(item);
+          tableLeftBorderPerRowArray.push(item)
           // 2024/01/19 10:42:28 @guoxiaona/GW00234847：需要从item中获取当前style中的height值，并放入borderHeightArray中
-          const style = item.style;
-          const height = Number(style.height.replace("px", ""));
-          borderHeightArray.push(height);
+          const style = item.style
+          const height = Number(style.height.replace('px', ''))
+          borderHeightArray.push(height)
         }
-      });
+      })
       // 2024/01/19 10:42:47 @guoxiaona/GW00234847：检测heightArray和borderHeightArray对应下标的数值相差是否在10(行高大于10)以内，如果是，则不做任何处理，否则更新当前行对应的高度
-      let ifRowHeightUpdated = false;
+      let ifRowHeightUpdated = false
       heightArray.forEach((item, index) => {
-        const borderHeight = borderHeightArray[index];
-        const itemNumber = Number(item);
-        const diff = Math.abs(borderHeight - itemNumber);
+        const borderHeight = borderHeightArray[index]
+        const itemNumber = Number(item)
+        const diff = Math.abs(borderHeight - itemNumber)
         // 2024/01/19 10:43:20 @guoxiaona/GW00234847：在这里更新当前行及后面行的高度及top值
         if (diff > 10 || ifRowHeightUpdated) {
-          ifRowHeightUpdated = true;
+          ifRowHeightUpdated = true
           // 2024/01/19 10:43:33 @guoxiaona/GW00234847：调整当前tableLeftBorderPerRowArray[index]的高度为heightArray[index] + 1,top为heightArrayMapOnlyPrev[index]
-          const currentRow = tableLeftBorderPerRowArray[index];
-          const currentRowStyle = currentRow.style;
-          currentRowStyle.height = `${itemNumber + 1}px`;
-          currentRowStyle.top = `${heightArrayMapOnlyPrev[index]}px`;
+          const currentRow = tableLeftBorderPerRowArray[index]
+          const currentRowStyle = currentRow.style
+          currentRowStyle.height = `${itemNumber + 1}px`
+          currentRowStyle.top = `${heightArrayMapOnlyPrev[index]}px`
           // 2024/01/19 10:43:47 @guoxiaona/GW00234847：调整当前tableLeftBorderPerRowArray[index]后面两个兄弟元素的top值为heightArrayMapAllPrev[index] - 1
           // 2024/01/19 10:44:00 @guoxiaona/GW00234847：需要重新获取后面两个兄弟元素，这两个兄弟元素没在tableLeftBorderPerRowArray[index]里
-          const nextSibling = currentRow.nextElementSibling;
-          const nextSiblingStyle = nextSibling.style;
-          nextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`;
-          const nextNextSibling = nextSibling.nextElementSibling;
-          const nextNextSiblingStyle = nextNextSibling.style;
-          nextNextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`;
+          const nextSibling = currentRow.nextElementSibling
+          const nextSiblingStyle = nextSibling.style
+          nextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`
+          const nextNextSibling = nextSibling.nextElementSibling
+          const nextNextSiblingStyle = nextNextSibling.style
+          nextNextSiblingStyle.top = `${heightArrayMapAllPrev[index] - 1}px`
         }
-      });
+      })
       // 2024/01/19 10:44:13 @guoxiaona/GW00234847：如果行高调整过，则需要对应调整列的高度为heightArrayMapAllPrev的最后一个元素的值 + 9
       if (ifRowHeightUpdated) {
         // 2024/01/19 10:44:25 @guoxiaona/GW00234847：获取tableTopBorder中所有子元素带有属性data-table-col的子元素，并放到一个数组中tableTopBorderPerColArray
-        const tableTopBorderChildrenArray = Array.from(
-          tableTopBorder?.children
-        );
-        const tableTopBorderPerColArray: any[] = [];
+        const tableTopBorderChildrenArray = Array.from(tableTopBorder?.children)
+        const tableTopBorderPerColArray: any[] = []
         tableTopBorderChildrenArray.forEach((item: any) => {
           if (item.dataset.tableCol) {
-            tableTopBorderPerColArray.push(item);
+            tableTopBorderPerColArray.push(item)
           }
-        });
+        })
         // 2024/01/19 10:44:46 @guoxiaona/GW00234847：遍历tableTopBorderPerColArray中每一个元素的兄弟节点的兄弟节点，找到后，将高度调整为heightArrayMapAllPrev的最后一个元素的值 + 9
-        tableTopBorderPerColArray.forEach((item) => {
-          const nextNextSibling = item.nextElementSibling.nextElementSibling;
-          const nextNextSiblingStyle = nextNextSibling.style;
+        tableTopBorderPerColArray.forEach(item => {
+          const nextNextSibling = item.nextElementSibling.nextElementSibling
+          const nextNextSiblingStyle = nextNextSibling.style
           nextNextSiblingStyle.height = `${
             heightArrayMapAllPrev[heightArrayMapAllPrev.length - 1] + 9
-          }px`;
-        });
+          }px`
+        })
       }
     }
 
@@ -352,7 +348,7 @@ const SplitActionDefault: React.FC<TableActionProps> = ({
     cancellablePromisesApi.clearPendingPromises()
     window.removeEventListener('mousemove', handleDragSplitMove)
     window.removeEventListener('mouseup', handleDragSplitUp)
-  }, [cancellablePromisesApi, dragRef, handleDragSplitMove])
+  }, [cancellablePromisesApi, dragRef, handleDragSplitMove, editor, minRowHeight, table])
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault()

--- a/packages/plugins/table/src/row/deserializer/html.ts
+++ b/packages/plugins/table/src/row/deserializer/html.ts
@@ -5,8 +5,8 @@ import {
 import { Editor, isDOMHTMLElement } from '@editablejs/models'
 import { TableCell } from '../../cell'
 import { TABLE_ROW_KEY } from '../constants'
-import { getOptions } from '../options'
 import { TableRow } from '../interfaces/table-row'
+import { getOptions } from '../options'
 
 export interface TableRowHTMLDeserializerOptions extends HTMLDeserializerOptions {
   editor: Editor
@@ -17,7 +17,7 @@ export const withTableRowHTMLDeserializerTransform: HTMLDeserializerWithTransfor
 > = (next, serializer, { editor }) => {
   return (node, options = {}) => {
     const { text } = options
-    if (isDOMHTMLElement(node) && ['TR', 'TH'].includes(node.tagName)) {
+    if (isDOMHTMLElement(node) && ['TR'].includes(node.tagName)) {
       const options = getOptions(editor)
       const h = (node as HTMLElement).style.height
       const height = parseInt(!h ? '0' : h, 10)

--- a/packages/plugins/table/src/table/deserializer/html.ts
+++ b/packages/plugins/table/src/table/deserializer/html.ts
@@ -25,9 +25,37 @@ export const withTableHTMLDeserializerTransform: HTMLDeserializerWithTransform<
         children.push(...(serializer.transform(child, { text, matchNewline: true }) as TableRow[]))
       }
       const { minColWidth = defaultTableMinColWidth } = getOptions(editor)
+      // start update col Taylor
+      let container = document.createElement('div');
+      container.style.visibility = 'hidden';
+      container.style.position = 'absolute';
+
+      container.appendChild(node);
+      const colgroup = node.querySelector('colgroup');
+      if (colgroup) {
+        node.removeChild(colgroup);
+      }
+      document.body.appendChild(container);
+      let firstRow = node.rows[0];
+      if (firstRow) {
+        let colgroup = document.createElement('colgroup');
+        for (let i = 0; i < firstRow.cells.length; i++) {
+          let cell = firstRow.cells[i];
+          let colspan = cell.colSpan;
+          for (let j = 0; j < colspan; j++) {
+            let col = document.createElement('col');
+            let width = colspan > 1 ? 90 : cell.offsetWidth;
+            col.style.width = `${width}px`;
+            colgroup.appendChild(col);
+          }
+        }
+        node.insertBefore(colgroup, node.firstChild);
+      }
+      document.body.removeChild(container);
+      // the end update col Taylor
       const colsWidth = Array.from(node.querySelectorAll('col')).map(c => {
         const w = c.width || c.style.width
-        return Math.min(parseInt(w === '' ? '0' : w, 10), minColWidth)
+        return Math.max(parseInt(w === '' ? '0' : w, 10), minColWidth)
       })
       const colCount = children[0].children.length
       if (colsWidth.length === 0) {

--- a/packages/plugins/table/src/table/deserializer/html.ts
+++ b/packages/plugins/table/src/table/deserializer/html.ts
@@ -44,7 +44,7 @@ export const withTableHTMLDeserializerTransform: HTMLDeserializerWithTransform<
           let colspan = cell.colSpan;
           for (let j = 0; j < colspan; j++) {
             let col = document.createElement('col');
-            let width = colspan > 1 ? 90 : cell.offsetWidth;
+            let width = cell.offsetWidth;
             col.style.width = `${width}px`;
             colgroup.appendChild(col);
           }


### PR DESCRIPTION
**Description**
When we tried to use this library on our project, we encountered some issues, so I temporarily fixed them through some scripts,  here comes the issues and solutions.
The following issues have been fixed: Page collapse issues caused by copied table: 
1. col span & row span greater than 1,  if click enter, page will collapse
2. TH element will be serialized like tr
3. The last empty cell missing issue
4. Link inside table cell can not correctly respond to enter event issue
5. Drag column will cause cell height update, but left border with drag function will stay the same
6. Some copied table with colgroup can not show column header because it just set all col width to 0.

**Issue**

Fixes: (link to issue)

**Example**

1. & 2.
before
![copy_table_rowspan_colspan_issue](https://github.com/guoxiaona-gwm/editable/assets/149048134/2b3fbed7-1f67-4238-94d5-b017834b10f8)

after
![copy_table_rowspan_colspan_issue_after](https://github.com/guoxiaona-gwm/editable/assets/149048134/4fd6c8c7-449a-4c93-8c5e-db7ab8523e3c)

3. 
before
![last_missing_cell](https://github.com/guoxiaona-gwm/editable/assets/149048134/68fd1d1c-d3d9-4679-8f52-0346ca1baa24)

after
![last_missing_cell_after](https://github.com/guoxiaona-gwm/editable/assets/149048134/226a333c-2737-4884-a64e-d4b381f4daa9)

4. Link issue
before
![Link_enter](https://github.com/guoxiaona-gwm/editable/assets/149048134/da62be9a-34a5-43fd-9597-ddb078c46074)


after
![Link_enter_after](https://github.com/guoxiaona-gwm/editable/assets/149048134/d2cea9de-7ef3-43b4-8446-7388f8b6d3e6)

5. Dragging column will cause cell height updating, but the left border with drag function will stay the same

before
![drag_table_column](https://github.com/guoxiaona-gwm/editable/assets/149048134/c7dbd057-2583-4505-93f1-ae8ca14a82fd)

after
![drag_table_column_after](https://github.com/guoxiaona-gwm/editable/assets/149048134/dd87abd7-a5bc-45e9-8753-28805d00d74e)

6. Copied table with colgroup can not drag column
before
![partial_table_col](https://github.com/guoxiaona-gwm/editable/assets/149048134/ae21b50d-bc2e-4127-ad06-a2f93f4904a7)

after
![partial_table_col_after](https://github.com/guoxiaona-gwm/editable/assets/149048134/73fc452e-651b-4f8f-957a-5234c78978e2)



**Context**
1: The raw HTML for the table, it will not display an empty dom cell for colspan or rowspan that is greater than 1, but just reduce the corresponding number of the cell. But in editablejs, the table will render every one of the cells even if it may ignored by the raw table. My solution is to fill the missing cell, calculate each line's colspan and rowspan, and if it is greater than 1,  add another td empty element with displaynone||||||, so when displaying the cell, it will also need to check if it contains displaynone|||||| to hide that cell. Once the data structure works fit to editablejs, it works fine.
2: TH works as a cell, so just need to remove- it from TR to TD. So TH will work as expected. 
3: Calculate the total cells of the first row of the table, when it comes to the final line of the table, check if the cell number fits = the same as the first row, if not, patch the missing cell.
4: when copying content into editablejs, its data structure didn't match what the editablejs requires, for it missing another wrapper outside children, it should be wrapped by children with children as the first element.
5: When dragging columns, it didn't update the height of the left border cell, however height of cells might update, whether gets smaller or higher. So it should recalculate the left border's height.
6: If the table has been wrapped inside by colgroup, it will auto-set each cols' width to 0 which finally causes column's width to 0, so what should be done is to check if there are any colgroup inside each table, and to reset each column's width to offsetWidth
**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The tests are the same result as the original library with `pnpm test`.
- [x] The linter passes with `pnpm lint`. (Fix errors with `pnpm fix`.)
- [x] The relevant examples still work. (Run examples with `pnpm start`.)
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm changeset`.)

